### PR TITLE
Change the method of obtaining TotalCommander path

### DIFF
--- a/Lib/GetPaths.ahk
+++ b/Lib/GetPaths.ahk
@@ -29,8 +29,9 @@ GetPaths(ByRef paths, _activeTabOnly := false, _showLockedTabs := false) {
         }
 
         try {
-            if !(%_winClass%(_winId, paths, _activeTabOnly, _showLockedTabs))
-                AddElevatedName(_winPid)
+            ; Call the appropriate function for this file manager class
+            ; Returns the number of paths added (0 if no unlocked tabs, not an error)
+            %_winClass%(_winId, paths, _activeTabOnly, _showLockedTabs)
 
         } catch _ex {
             ; Assume that the file manager is elevated

--- a/Lib/TotalCommander.ahk
+++ b/Lib/TotalCommander.ahk
@@ -6,60 +6,66 @@
 
 TTOTAL_CMD(ByRef winId, ByRef paths, _activeTabOnly := false, _showLockedTabs := false) {
     /*
-        Requests tabs file.
+        Gets current browsing paths from both panels.
+        Active panel path is added first for AutoSwitch.
+    */
+    return GetTotalPanelPaths(winId, paths)
+}
 
-        If unsuccessful, searches for the location of wincmd.ini to create usercmd.ini
-        in that directory with the EM_ user command to export tabs to the file
+GetTotalPanelPaths(ByRef winId, ByRef paths) {
+    /*
+        Gets current browsing paths from both panels.
+        - Window9: Active panel path (ends with ">")
+        - Window13: Left panel path (ends with "*.*")
+        - Window18: Right panel path (ends with "*.*")
+        Active panel path is added first for AutoSwitch.
     */
 
-    static userCmd      :=  "EM_ScriptCommand_QuickSwitch_SaveAllTabs2"
-         , internalCmd  :=  "SaveTabs2"
-         , tabsDir      :=  A_Temp "\TotalTabs"
-         , tabsFile     :=  tabsDir "\TotalTabs.tab"
-         , lastWinId    :=  0
-         , userIni      :=  ""
-    
-    try {
-        if (_activeTabOnly && _showLockedTabs)
-            return GetTotalActiveTab(winId, paths)
-        
-        SendTotalUserCmd(winId, userCmd)       
-        WaitForTabs(tabsDir, tabsFile)
-        
-        if _activeTabOnly
-            return GetTotalUnlockedTab(tabsFile, paths)
-        
-        return ParseTotalTabs(tabsFile, paths, _showLockedTabs)
-        
-    } catch _ex {
-        ; Get proccess permissions
-        WinGet, _winPid, % "pid", % "ahk_id " winId        
-        if (!A_IsAdmin && IsProcessElevated(_winPid))
-            throw Exception("Unable to obtain TotalCmd paths"
-                          , "admin permission"
-                          , _ex.what " " _ex.message " " _ex.extra)
-        
-        ; Check if required dir exists
-        dirWasCreated := false 
-        if !FileExist(tabsDir) {
-            FileCreateDir % tabsDir
-            dirWasCreated := true
-        }
-        
-        ; Create user command and retry
-        if (lastWinId != winId) {
-            LogInfo("Required to create user command: [" userCmd "]", "NoTraytip")
-            userIni := GetTotalIni(winId, _winPid)
-        }
-        lastWinId := winId
-        
-        ; Retry if user command or new dir was successfully created
-        if (CreateTotalUserCmd(userIni, userCmd, internalCmd, tabsFile)
-         || dirWasCreated) {
-            return TTOTAL_CMD(winId, paths, _activeTabOnly, _showLockedTabs)
-        }
-        
-        ; The user command already exists. Re-throw exception to the caller      
-        throw _ex
+    _leftPath := ""
+    _rightPath := ""
+    _activePath := ""
+
+    ; Get active panel path from Window9 (ends with ">")
+    ControlGetText, _text, % "Window9", % "ahk_id " winId
+    if InStr(_text, ":\") && InStr(_text, ">") {
+        _activePath := RTrim(_text, ">")
     }
+
+    ; Get left panel path from Window13
+    ControlGetText, _text, % "Window13", % "ahk_id " winId
+    if InStr(_text, ":\") && RegExMatch(_text, "\*\.\*$") {
+        _leftPath := RegExReplace(_text, "\*\.\*$", "")
+        _leftPath := RTrim(_leftPath, "\")
+    }
+
+    ; Get right panel path from Window18
+    ControlGetText, _text, % "Window18", % "ahk_id " winId
+    if InStr(_text, ":\") && RegExMatch(_text, "\*\.\*$") {
+        _rightPath := RegExReplace(_text, "\*\.\*$", "")
+        _rightPath := RTrim(_rightPath, "\")
+    }
+
+    LogInfo("TC active: [" _activePath "] left: [" _leftPath "] right: [" _rightPath "]", "NoTraytip")
+
+    _count := 0
+
+    ; Add active panel path first (for AutoSwitch)
+    if (_activePath != "") {
+        paths.push([_activePath, "TotalCmd.ico", 1, ""])
+        _count++
+    }
+
+    ; Add left panel path if not active
+    if (_leftPath != "" && _leftPath != _activePath) {
+        paths.push([_leftPath, "TotalCmd.ico", 1, ""])
+        _count++
+    }
+
+    ; Add right panel path if not active
+    if (_rightPath != "" && _rightPath != _activePath) {
+        paths.push([_rightPath, "TotalCmd.ico", 1, ""])
+        _count++
+    }
+
+    return _count
 }


### PR DESCRIPTION
# Project Code Changes Summary

Generated Date: 2026-03-03

---

## I. Modified Files

### 1. Lib/GetPaths.ahk

**Change Location:** Lines 31-33

**Before:**
```ahk
try {
    if !(%_winClass%(_winId, paths, _activeTabOnly, _showLockedTabs))
        AddElevatedName(_winPid)
```

**After:**
```ahk
try {
    ; Call the appropriate function for this file manager class
    ; Returns the number of paths added (0 if no unlocked tabs, not an error)
    %_winClass%(_winId, paths, _activeTabOnly, _showLockedTabs)
```

**Change Description:**
- Removed conditional check and `AddElevatedName` call
- Added comment explaining that the function returns the number of paths added
- Simplified the calling logic, no longer handling false return values

---

### 2. Lib/TotalCommander.ahk

**Change Type:** Complete rewrite

**Before (Old Implementation):**
- Used `EM_ScriptCommand_QuickSwitch_SaveAllTabs2` user command to request tab file export
- Created `usercmd.ini` configuration through `wincmd.ini`
- Parsed `.tab` files to get path information
- Supported active tabs, locked tabs, and other options

**After (New Implementation):**
```ahk
TTOTAL_CMD(ByRef winId, ByRef paths, _activeTabOnly := false, _showLockedTabs := false) {
    /*
        Gets current browsing paths from both panels.
        Active panel path is added first for AutoSwitch.
    */
    return GetTotalPanelPaths(winId, paths)
}

GetTotalPanelPaths(ByRef winId, ByRef paths) {
    /*
        Gets current browsing paths from both panels.
        - Window9: Active panel path (ends with ">")
        - Window13: Left panel path (ends with "*.*")
        - Window18: Right panel path (ends with "*.*")
        Active panel path is added first for AutoSwitch.
    */

    _leftPath := ""
    _rightPath := ""
    _activePath := ""

    ; Get active panel path from Window9 (ends with ">")
    ControlGetText, _text, % "Window9", % "ahk_id " winId
    if InStr(_text, ":\") && InStr(_text, ">") {
        _activePath := RTrim(_text, ">")
    }

    ; Get left panel path from Window13
    ControlGetText, _text, % "Window13", % "ahk_id " winId
    if InStr(_text, ":\") && RegExMatch(_text, "\*\.\*$") {
        _leftPath := RegExReplace(_text, "\*\.\*$", "")
        _leftPath := RTrim(_leftPath, "\")
    }

    ; Get right panel path from Window18
    ControlGetText, _text, % "Window18", % "ahk_id " winId
    if InStr(_text, ":\") && RegExMatch(_text, "\*\.\*$") {
        _rightPath := RegExReplace(_text, "\*\.\*$", "")
        _rightPath := RTrim(_rightPath, "\")
    }

    LogInfo("TC active: [" _activePath "] left: [" _leftPath "] right: [" _rightPath "]", "NoTraytip")

    _count := 0

    ; Add active panel path first (for AutoSwitch)
    if (_activePath != "") {
        paths.push([_activePath, "TotalCmd.ico", 1, ""])
        _count++
    }

    ; Add left panel path if not active
    if (_leftPath != "" && _leftPath != _activePath) {
        paths.push([_leftPath, "TotalCmd.ico", 1, ""])
        _count++
    }

    ; Add right panel path if not active
    if (_rightPath != "" && _rightPath != _activePath) {
        paths.push([_rightPath, "TotalCmd.ico", 1, ""])
        _count++
    }

    return _count
}
```

**Change Description:**
- **Implementation completely changed**: From "request tab file" method to "directly read path control text" method
- **Removed Features:**
  - Removed static variables: `userCmd`, `internalCmd`, `tabsDir`, `tabsFile`
  - Removed helper function calls: `SendTotalUserCmd`, `WaitForTabs`, `ParseTotalTabs`
  - Removed admin privilege check and usercmd.ini creation logic
  - Removed actual processing of `_activeTabOnly` and `_showLockedTabs` parameters

- **New Features:**
  - Added `GetTotalPanelPaths` function
  - Get paths by reading TC window controls directly:
    - `Window9`: Active panel path (ends with `>`)
    - `Window13`: Left panel path (ends with `*.*`)
    - `Window18`: Right panel path (ends with `*.*`)
  - Active panel path is added first (for AutoSwitch feature)
  - Avoid adding duplicate paths

---

## II. Impact Analysis

| Aspect | Old Implementation | New Implementation |
|--------|-------------------|-------------------|
| **Complexity** | High (requires config file creation, tab export) | Low (direct control reading) |
| **Dependencies** | Requires usercmd.ini configuration | No additional dependencies |
| **Privilege Requirements** | May require admin privileges | No special privilege requirements |
| **Feature Scope** | Supports multiple tabs, locked tabs | Only supports current two panels |
| **Reliability** | Depends on file system operations | Direct memory reading, more reliable |
| **Performance** | Slower (requires waiting for file export) | Faster (direct reading) |

**Notes:**
- New implementation simplifies functionality but loses multi-tab support
- `_activeTabOnly` and `_showLockedTabs` parameters are ignored in the new implementation
- If multi-tab functionality needs to be restored, the old code needs to be preserved or re-implemented
